### PR TITLE
adding fleet service

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ week-end. You can override with `--maxAge [duration]` using Golang duration synt
 For your convenience, docker-gc is also available as a docker image. You can run it as `docker run -d -v /var/run/docker.sock:/var/run/docker.sock ndeloof/docker-gc`
 You need to bind mount `/var/run/docker.sock` from docker host so the docker-gc process can attach to the daemon to listen for event and inspect/remove images.
 
+You can also use `docker-gc.service` to deploy Docker-gc everywhere using [Fleet](https://coreos.com/fleet/docs/latest/) on a CoreOS cluster. Just run `fleetctl start docker-gc.service`.

--- a/docker-gc.service
+++ b/docker-gc.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Docker-gc Service
+After=docker.service
+Requires=docker.service
+[Service]
+Restart=always
+ExecStartPre=-/usr/bin/docker kill docker-gc
+ExecStartPre=-/usr/bin/docker rm docker-gc
+ExecStartPre=/usr/bin/docker pull ndeloof/docker-gc:latest
+ExecStart=/usr/bin/docker run -v /var/run/docker.sock:/var/run/docker.sock --name=docker-gc ndeloof/docker-gc
+ExecStop=/usr/bin/docker stop -t 2 docker-gc
+
+[Install]
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=true


### PR DESCRIPTION
I'm using a CoreOS instance. This fleet file allows docker-gc to be run on every instance of my cluster.
